### PR TITLE
Declaration Warning on WCS_Query Class

### DIFF
--- a/includes/class-wcs-query.php
+++ b/includes/class-wcs-query.php
@@ -101,7 +101,7 @@ class WCS_Query extends WC_Query {
 	 * @since 2.0
 	 * @param $title
 	 */
-	public function get_endpoint_title( $endpoint ) {
+	public function get_endpoint_title( $endpoint, $action = ''  ) {
 		global $wp;
 
 		switch ( $endpoint ) {


### PR DESCRIPTION
When try install the plugin, i get the Warning: Declaration of WCS_Query::get_endpoint_title() should be compatible with WC_Query::get_endpoint_title(,  = '')

If we analise the WC_Query Class on Woocommerce
	/**
	 * Get page title for an endpoint.
	 *
	 * @param string $endpoint Endpoint key.
	 * @param string $action Optional action or variation within the endpoint.
	 *
	 * @since 2.3.0
	 * @since 4.6.0 Added $action parameter.
	 * @return string The page title.
	 */ 
On WooCommerce 4.6.0  the $action parameter  was added,
On WooCommerce Subscriptions 3.0.10 this warning was fixed.
